### PR TITLE
Make CollectionBlock addable on plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make CollectionBlock addable on plone site per default [raphael-s]
 
 
 1.0.3 (2016-09-26)

--- a/ftw/collectionblock/profiles/default/types/Plone_Site.xml
+++ b/ftw/collectionblock/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.collectionblock.CollectionBlock" />
+    </property>
+
+</object>


### PR DESCRIPTION
When `ftw.collectionblock` is installed the CollectionBlock can now be added to plone site per default.

We don't want an upgrade step for this because we don't want to change how existing deployments handle the CollectionBlock.