### PR TITLE
Add setting to hide "more" link

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add setting to hide "more" button [raphael-s]
 
 
 1.0.4 (2017-03-07)

--- a/ftw/collectionblock/browser/block_view.py
+++ b/ftw/collectionblock/browser/block_view.py
@@ -58,6 +58,7 @@ class CollectionBlockView(BaseBlock):
             'more_link_url': more_link_url,
             'more_link_label': more_link_label,
             'rss_link_url': rss_link_url or '',
+            'show_more_link': self.context.show_more_link,
         }
 
         return info

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -37,12 +37,13 @@
 
         <tal:footer tal:define="more_link_url block_info/more_link_url;
                                 more_link_label block_info/more_link_label;
-                                rss_url block_info/rss_link_url"
+                                rss_url block_info/rss_link_url;
+                                show_more_link block_info/show_more_link"
                     tal:condition="items">
             <div class="collection-footer"
                  tal:condition="python: more_link_url or rss_url">
                     <a class="collection-more"
-                       tal:condition="more_link_url"
+                       tal:condition="python:more_link_url and show_more_link"
                        title="More"
                        i18n:attributes="title more_link_label"
                        tal:attributes="href more_link_url"

--- a/ftw/collectionblock/contents/collectionblock.py
+++ b/ftw/collectionblock/contents/collectionblock.py
@@ -44,6 +44,11 @@ class ICollectionBlockSchema(model.Schema):
         default=False,
     )
 
+    show_more_link = schema.Bool(
+        title=_(u'label_show_more_link', default=u'Show "more" link'),
+        default=True,
+    )
+
     more_link_label = schema.TextLine(
         title=_(u'label_more_link_label',
                 default=u'Label for the "more" link'),

--- a/ftw/collectionblock/locales/de/LC_MESSAGES/ftw.collectionblock.po
+++ b/ftw/collectionblock/locales/de/LC_MESSAGES/ftw.collectionblock.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-08-12 09:57+0000\n"
+"POT-Creation-Date: 2017-06-23 11:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,9 +59,14 @@ msgid "label_block_amount"
 msgstr "Anzahl Einträge"
 
 #. Default: "Label for the \"more\" link"
-#: ./ftw/collectionblock/contents/collectionblock.py:48
+#: ./ftw/collectionblock/contents/collectionblock.py:53
 msgid "label_more_link_label"
 msgstr "Label for the \"Mehr\"-Link"
+
+#. Default: "Show \"more\" link"
+#: ./ftw/collectionblock/contents/collectionblock.py:48
+msgid "label_show_more_link"
+msgstr "\"Mehr\"-Link anzeigen"
 
 #. Default: "Link to RSS feed"
 #: ./ftw/collectionblock/contents/collectionblock.py:42

--- a/ftw/collectionblock/locales/ftw.collectionblock.pot
+++ b/ftw/collectionblock/locales/ftw.collectionblock.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-08-12 09:57+0000\n"
+"POT-Creation-Date: 2017-06-23 11:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,8 +59,13 @@ msgid "label_block_amount"
 msgstr ""
 
 #. Default: "Label for the \"more\" link"
-#: ./ftw/collectionblock/contents/collectionblock.py:48
+#: ./ftw/collectionblock/contents/collectionblock.py:53
 msgid "label_more_link_label"
+msgstr ""
+
+#. Default: "Show \"more\" link"
+#: ./ftw/collectionblock/contents/collectionblock.py:48
+msgid "label_show_more_link"
 msgstr ""
 
 #. Default: "Link to RSS feed"

--- a/ftw/collectionblock/tests/test_hide_more_link_setting.py
+++ b/ftw/collectionblock/tests/test_hide_more_link_setting.py
@@ -1,0 +1,43 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.collectionblock.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+
+
+class TestHideMoreLinkSetting(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestHideMoreLinkSetting, self).setUp()
+        self.grant('Manager')
+
+        self.page = create(Builder('sl content page').titled(u'A page'))
+
+    @browsing
+    def test_more_link_is_visible_when_option_is_checked(self, browser):
+        create(Builder('sl collectionblock')
+               .titled(u'A collectionblock')
+               .having(show_more_link=True)
+               .within(self.page)
+               .with_default_query())
+
+        browser.visit(self.page)
+
+        self.assertEqual(
+            ['More'],
+            [item.text for item in browser.css('.collection-more')]
+        )
+
+    @browsing
+    def test_more_link_is_hidden_when_option_is_unchecked(self, browser):
+        create(Builder('sl collectionblock')
+               .titled(u'A collectionblock')
+               .having(show_more_link=False)
+               .within(self.page)
+               .with_default_query())
+
+        browser.visit(self.page)
+
+        self.assertEqual(
+            [],
+            [item.text for item in browser.css('.collection-more')]
+        )


### PR DESCRIPTION
Adds a checkbox to the collection block which allows the user to hide the "more" link at the bottom of the block.

Block-Settings:
<img width="1440" alt="screen shot 2017-06-23 at 14 30 39" src="https://user-images.githubusercontent.com/16755391/27482337-56e65e3e-5821-11e7-9d1a-226eb72b762d.png">

Block when box is checked:
<img width="1214" alt="screen shot 2017-06-23 at 14 31 19" src="https://user-images.githubusercontent.com/16755391/27482389-8c9a4fea-5821-11e7-8927-209d536cfdd7.png">

Block when box is unchecked:
<img width="1215" alt="screen shot 2017-06-23 at 14 37 34" src="https://user-images.githubusercontent.com/16755391/27482438-bd4dae98-5821-11e7-8b2a-b064eb40ffaf.png">

