### PR TITLE
Fix initilize the querywidget for the add/edit form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix initilize the querywidget for the add/edit form. [busykoala]
 
 
 1.0.5 (2017-06-27)

--- a/ftw/collectionblock/browser/resources/collectionblock.js
+++ b/ftw/collectionblock/browser/resources/collectionblock.js
@@ -4,6 +4,7 @@
 
   $(function() {
     $(document).on("onLoad", ".overlay", function() {
+      $.querywidget.initialized = false;
       $.querywidget.init();
 
       // We need two keep two fields for each sorting field ('#sort_on',


### PR DESCRIPTION
When the collection-block overlay was opened the second time some JS functions weren't initialised properly.