### PR TITLE
Change current view to a tabular view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change list layout to table layout. [busykoala]
 
 
 1.0.6 (2018-09-27)

--- a/ftw/collectionblock/browser/block_view.py
+++ b/ftw/collectionblock/browser/block_view.py
@@ -3,6 +3,7 @@ from Products.CMFPlone.interfaces.syndication import IFeedSettings
 from Products.CMFPlone.utils import safe_callable
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ftw.collectionblock import _
+from plone.app.collection import PloneMessageFactory as PMF
 from ftw.collectionblock import utils
 from ftw.simplelayout.browser.blocks.base import BaseBlock
 from plone.app.contenttypes.behaviors.collection import ICollection

--- a/ftw/collectionblock/browser/block_view.py
+++ b/ftw/collectionblock/browser/block_view.py
@@ -97,7 +97,7 @@ class CollectionBlockView(BaseBlock):
             value = self.toLocalizedTime(value, long_format=1)
 
         return {
-            # 'title': _(fieldname, default=fieldname),
+            'title': PMF(fieldname),
             'value': value
         }
 

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -14,10 +14,10 @@
         <p tal:condition="not: items"
             i18n:translate="">No content available</p>
 
-        <table class="listing">
+        <table class="listing sortable">
             <thead>
                 <tr>
-                    <th class="nosort"
+                    <td i18n:domain="plone"
                         i18n:translate=""
                         tal:repeat="field view/tabular_fields"
                         tal:content="field" />

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -48,6 +48,7 @@
                                 </td>
                                 <td tal:condition="python:field == 'Title'">
                                     <a tal:condition="python:item_type == 'File'"
+                                       i18n:attributes="title"
                                        tal:attributes="href item_url;
                                                        class string:$item_type_class $item_wf_state_class;
                                                        title item_type">
@@ -57,14 +58,15 @@
                                     <a tal:attributes="href item_url;
                                                        class string:$item_type_class $item_wf_state_class;
                                                        title item_type"
-                                       tal:content="item_title">Item Title</a>
+                                       tal:content="item_title" />
                                 </td>
                                 <td tal:condition="python:field == 'Creator'"
+                                    i18n:attributes="creator"
                                     tal:define="author python:view.pas_member.info(item_creator);
                                     name python:author['fullname'] or author['username']">
                                     <a tal:condition="author"
                                        tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
-                                       tal:content="name">Jos Henken</a>
+                                       tal:content="name" />
                                 </td>
                             </tal:block>
 

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -1,6 +1,6 @@
 <html xmlns:tal="http://xml.zope.org/namespaces/tal"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    tal:omit-tag="python: 1"   
+    tal:omit-tag="python: 1"
     i18n:domain="ftw.collectionblock"
     tal:define="block_info view/get_block_info">
 
@@ -9,7 +9,7 @@
     </h2>
 
     <tal:items tal:define="items view/block_results;
-                            normalizeString nocall:context/@@plone/normalizeString">
+        normalizeString nocall:context/@@plone/normalizeString">
 
         <p tal:condition="not: items"
             i18n:translate="">No content available</p>
@@ -26,17 +26,17 @@
             <tbody>
                 <tal:entries tal:repeat="item items">
                     <tal:block tal:define="item_url item/getURL;
-                                     item_id item/getId;
-                                     item_title item/Title;
-                                     item_title python:item_title or item_id;
-                                     item_description item/Description;
-                                     item_type item/PortalType;
-                                     item_type_class python:'contenttype-' + normalizeString(item_type);
-                                     item_wf_state item/review_state;
-                                     item_wf_state_class python:'state-' + normalizeString(item_wf_state);
-                                     item_creator item/Creator;
-                                     item_has_image python:item.getIcon;
-                                     ">
+                        item_id item/getId;
+                        item_title item/Title;
+                        item_title python:item_title or item_id;
+                        item_description item/Description;
+                        item_type item/PortalType;
+                        item_type_class python:'contenttype-' + normalizeString(item_type);
+                        item_wf_state item/review_state;
+                        item_wf_state_class python:'state-' + normalizeString(item_wf_state);
+                        item_creator item/Creator;
+                        item_has_image python:item.getIcon;
+                        ">
                         <tr metal:define-macro="listitem"
                             tal:define="oddrow repeat/item/odd;"
                             tal:attributes="class python: oddrow and 'even' or 'odd'">
@@ -47,38 +47,53 @@
                                     <tal:block tal:replace="field_data/value" />
                                 </td>
                                 <td tal:condition="python:field == 'Title'">
-                                    <a tal:condition="python:item_type == 'File'" tal:attributes="href item_url;
+                                    <a tal:condition="python:item_type == 'File'"
+                                        tal:attributes="href item_url;
+                                        class string:$item_type_class $item_wf_state_class url;
+                                        title item_type">
+                                        <img class="mime-icon"
+                                            tal:attributes="src item/MimeTypeIcon">
+                                    </a>
+                                    <a tal:attributes="href item_url;
                                          class string:$item_type_class $item_wf_state_class url;
-                                         title item_type">
-                                        <img class="mime-icon" tal:attributes="src item/MimeTypeIcon">
-                                        </a>
-                                        <a tal:attributes="href item_url;
-                                         class string:$item_type_class $item_wf_state_class url;
-                                         title item_type" tal:content="item_title">Item Title
-                                        </a>
-                                    </td>
-                                    <td tal:condition="python:field == 'Creator'" tal:define="author python:view.pas_member.info(item_creator);
+                                         title item_type"
+                                         tal:content="item_title">Item Title</a>
+                                </td>
+                                <td tal:condition="python:field == 'Creator'"
+                                    tal:define="author python:view.pas_member.info(item_creator);
                                     name python:author['fullname'] or author['username']">
-                                        <a tal:condition="author" tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}" tal:content="name">Jos Henken</a>
-                                    </td>
-                                </tal:block>
+                                    <a tal:condition="author"
+                                        tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
+                                        tal:content="name">Jos Henken</a>
+                                </td>
+                            </tal:block>
 
-                            </tr>
-                        </tal:block>
-                    </tal:entries>
-                </tbody>
-            </table>
+                        </tr>
+                    </tal:block>
+                </tal:entries>
+            </tbody>
+        </table>
 
-            <tal:footer tal:define="more_link_url block_info/more_link_url;
-                                more_link_label block_info/more_link_label;
-                                rss_url block_info/rss_link_url;
-                                show_more_link block_info/show_more_link" tal:condition="items">
-                <div class="collection-footer" tal:condition="python: more_link_url or rss_url">
-                    <a class="collection-more" tal:condition="python:more_link_url and show_more_link" title="More" i18n:attributes="title more_link_label" tal:attributes="href more_link_url" tal:content="more_link_label"/>
-                    <a class="collection-rss" tal:condition="rss_url" tal:attributes="href rss_url" i18n:translate="">Subscribe to the RSS feed</a>
-                </div>
-            </tal:footer>
+        <tal:footer tal:define="more_link_url block_info/more_link_url;
+            more_link_label block_info/more_link_label;
+            rss_url block_info/rss_link_url;
+            show_more_link block_info/show_more_link"
+            tal:condition="items">
+            <div class="collection-footer"
+                tal:condition="python: more_link_url or rss_url">
+                <a class="collection-more"
+                    tal:condition="python:more_link_url and show_more_link"
+                    title="More"
+                    i18n:attributes="title more_link_label"
+                    tal:attributes="href more_link_url"
+                    tal:content="more_link_label"/>
+                <a class="collection-rss"
+                    tal:condition="rss_url"
+                    tal:attributes="href rss_url"
+                    i18n:translate="">Subscribe to the RSS feed</a>
+            </div>
+        </tal:footer>
 
-        </tal:items>
+    </tal:items>
 
-    </html>
+</html>

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -49,13 +49,13 @@
                                 <td tal:condition="python:field == 'Title'">
                                     <a tal:condition="python:item_type == 'File'"
                                        tal:attributes="href item_url;
-                                                       class string:$item_type_class $item_wf_state_class url;
+                                                       class string:$item_type_class $item_wf_state_class;
                                                        title item_type">
                                         <img class="mime-icon"
                                              tal:attributes="src item/MimeTypeIcon">
                                     </a>
                                     <a tal:attributes="href item_url;
-                                                       class string:$item_type_class $item_wf_state_class url;
+                                                       class string:$item_type_class $item_wf_state_class;
                                                        title item_type"
                                        tal:content="item_title">Item Title</a>
                                 </td>

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -1,8 +1,8 @@
 <html xmlns:tal="http://xml.zope.org/namespaces/tal"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    tal:omit-tag="python: 1"
-    i18n:domain="ftw.collectionblock"
-    tal:define="block_info view/get_block_info">
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag="python: 1"
+      i18n:domain="ftw.collectionblock"
+      tal:define="block_info view/get_block_info">
 
     <h2 tal:content="block_info/title"
         tal:condition="block_info/show_title">
@@ -12,7 +12,7 @@
         normalizeString nocall:context/@@plone/normalizeString">
 
         <p tal:condition="not: items"
-            i18n:translate="">No content available</p>
+           i18n:translate="">No content available</p>
 
         <table class="listing sortable">
             <thead>
@@ -26,16 +26,16 @@
             <tbody>
                 <tal:entries tal:repeat="item items">
                     <tal:block tal:define="item_url item/getURL;
-                        item_id item/getId;
-                        item_title item/Title;
-                        item_title python:item_title or item_id;
-                        item_description item/Description;
-                        item_type item/PortalType;
-                        item_type_class python:'contenttype-' + normalizeString(item_type);
-                        item_wf_state item/review_state;
-                        item_wf_state_class python:'state-' + normalizeString(item_wf_state);
-                        item_creator item/Creator;
-                        item_has_image python:item.getIcon;
+                                           item_id item/getId;
+                                           item_title item/Title;
+                                           item_title python:item_title or item_id;
+                                           item_description item/Description;
+                                           item_type item/PortalType;
+                                           item_type_class python:'contenttype-' + normalizeString(item_type);
+                                           item_wf_state item/review_state;
+                                           item_wf_state_class python:'state-' + normalizeString(item_wf_state);
+                                           item_creator item/Creator;
+                                           item_has_image python:item.getIcon;
                         ">
                         <tr metal:define-macro="listitem"
                             tal:define="oddrow repeat/item/odd;"
@@ -48,23 +48,23 @@
                                 </td>
                                 <td tal:condition="python:field == 'Title'">
                                     <a tal:condition="python:item_type == 'File'"
-                                        tal:attributes="href item_url;
-                                        class string:$item_type_class $item_wf_state_class url;
-                                        title item_type">
+                                       tal:attributes="href item_url;
+                                                       class string:$item_type_class $item_wf_state_class url;
+                                                       title item_type">
                                         <img class="mime-icon"
-                                            tal:attributes="src item/MimeTypeIcon">
+                                             tal:attributes="src item/MimeTypeIcon">
                                     </a>
                                     <a tal:attributes="href item_url;
-                                         class string:$item_type_class $item_wf_state_class url;
-                                         title item_type"
-                                         tal:content="item_title">Item Title</a>
+                                                       class string:$item_type_class $item_wf_state_class url;
+                                                       title item_type"
+                                       tal:content="item_title">Item Title</a>
                                 </td>
                                 <td tal:condition="python:field == 'Creator'"
                                     tal:define="author python:view.pas_member.info(item_creator);
                                     name python:author['fullname'] or author['username']">
                                     <a tal:condition="author"
-                                        tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
-                                        tal:content="name">Jos Henken</a>
+                                       tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
+                                       tal:content="name">Jos Henken</a>
                                 </td>
                             </tal:block>
 
@@ -82,15 +82,15 @@
             <div class="collection-footer"
                 tal:condition="python: more_link_url or rss_url">
                 <a class="collection-more"
-                    tal:condition="python:more_link_url and show_more_link"
-                    title="More"
-                    i18n:attributes="title more_link_label"
-                    tal:attributes="href more_link_url"
-                    tal:content="more_link_label"/>
+                   tal:condition="python:more_link_url and show_more_link"
+                   title="More"
+                   i18n:attributes="title more_link_label"
+                   tal:attributes="href more_link_url"
+                   tal:content="more_link_label"/>
                 <a class="collection-rss"
-                    tal:condition="rss_url"
-                    tal:attributes="href rss_url"
-                    i18n:translate="">Subscribe to the RSS feed</a>
+                   tal:condition="rss_url"
+                   tal:attributes="href rss_url"
+                   i18n:translate="">Subscribe to the RSS feed</a>
             </div>
         </tal:footer>
 

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -1,60 +1,84 @@
 <html xmlns:tal="http://xml.zope.org/namespaces/tal"
-      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-      tal:omit-tag="python: 1"
-      i18n:domain="ftw.collectionblock"
-      tal:define="block_info view/get_block_info">
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    tal:omit-tag="python: 1"   
+    i18n:domain="ftw.collectionblock"
+    tal:define="block_info view/get_block_info">
 
     <h2 tal:content="block_info/title"
         tal:condition="block_info/show_title">
     </h2>
 
-    <tal:items tal:define="items view/block_results;">
+    <tal:items tal:define="items view/block_results;
+                            normalizeString nocall:context/@@plone/normalizeString">
 
         <p tal:condition="not: items"
-           i18n:translate="">No content available</p>
+            i18n:translate="">No content available</p>
 
-        <ul class="collection-row" tal:condition="items">
-            <li class="collection-item" tal:repeat="item items">
-                <a class="collection-item" tal:attributes="href item/getURL">
-                    <div class="collection-body">
-                        <span class="byline">
-                            <span tal:content="python: view.toLocalizedTime(item)"/>
-                            <tal:author condition="python:view.get_author(item)">
-                                <span i18n:translate="collection_listing_author_label">
-                                    by
-                                    <span tal:content="python:view.get_author(item)"
-                                          i18n:name="author">Author</span>
-                                </span>
-                            </tal:author>
-                        </span>
-                        <h3 class="title" tal:content="item/Title" />
-                        <span class="description" tal:content="item/Description">Description</span>
-                    </div>
-                </a>
-            </li>
+        <table class="listing">
+            <thead>
+                <tr>
+                    <th class="nosort"
+                        i18n:translate=""
+                        tal:repeat="field view/tabular_fields"
+                        tal:content="field" />
+                </tr>
+            </thead>
+            <tbody>
+                <tal:entries tal:repeat="item items">
+                    <tal:block tal:define="item_url item/getURL;
+                                     item_id item/getId;
+                                     item_title item/Title;
+                                     item_title python:item_title or item_id;
+                                     item_description item/Description;
+                                     item_type item/PortalType;
+                                     item_type_class python:'contenttype-' + normalizeString(item_type);
+                                     item_wf_state item/review_state;
+                                     item_wf_state_class python:'state-' + normalizeString(item_wf_state);
+                                     item_creator item/Creator;
+                                     item_has_image python:item.getIcon;
+                                     ">
+                        <tr metal:define-macro="listitem"
+                            tal:define="oddrow repeat/item/odd;"
+                            tal:attributes="class python: oddrow and 'even' or 'odd'">
 
-        </ul>
+                            <tal:block tal:repeat="field view/tabular_fields">
+                                <td tal:condition="python:field not in ['Title', 'Creator']"
+                                    tal:define="field_data python:view.tabular_fielddata(item, field)">
+                                    <tal:block tal:replace="field_data/value" />
+                                </td>
+                                <td tal:condition="python:field == 'Title'">
+                                    <a tal:condition="python:item_type == 'File'" tal:attributes="href item_url;
+                                         class string:$item_type_class $item_wf_state_class url;
+                                         title item_type">
+                                        <img class="mime-icon" tal:attributes="src item/MimeTypeIcon">
+                                        </a>
+                                        <a tal:attributes="href item_url;
+                                         class string:$item_type_class $item_wf_state_class url;
+                                         title item_type" tal:content="item_title">Item Title
+                                        </a>
+                                    </td>
+                                    <td tal:condition="python:field == 'Creator'" tal:define="author python:view.pas_member.info(item_creator);
+                                    name python:author['fullname'] or author['username']">
+                                        <a tal:condition="author" tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}" tal:content="name">Jos Henken</a>
+                                    </td>
+                                </tal:block>
 
-        <tal:footer tal:define="more_link_url block_info/more_link_url;
+                            </tr>
+                        </tal:block>
+                    </tal:entries>
+                </tbody>
+            </table>
+
+            <tal:footer tal:define="more_link_url block_info/more_link_url;
                                 more_link_label block_info/more_link_label;
                                 rss_url block_info/rss_link_url;
-                                show_more_link block_info/show_more_link"
-                    tal:condition="items">
-            <div class="collection-footer"
-                 tal:condition="python: more_link_url or rss_url">
-                    <a class="collection-more"
-                       tal:condition="python:more_link_url and show_more_link"
-                       title="More"
-                       i18n:attributes="title more_link_label"
-                       tal:attributes="href more_link_url"
-                       tal:content="more_link_label"/>
-                    <a class="collection-rss"
-                       tal:condition="rss_url"
-                       tal:attributes="href rss_url"
-                       i18n:translate="">Subscribe to the RSS feed</a>
-               </div>
-        </tal:footer>
+                                show_more_link block_info/show_more_link" tal:condition="items">
+                <div class="collection-footer" tal:condition="python: more_link_url or rss_url">
+                    <a class="collection-more" tal:condition="python:more_link_url and show_more_link" title="More" i18n:attributes="title more_link_label" tal:attributes="href more_link_url" tal:content="more_link_label"/>
+                    <a class="collection-rss" tal:condition="rss_url" tal:attributes="href rss_url" i18n:translate="">Subscribe to the RSS feed</a>
+                </div>
+            </tal:footer>
 
-    </tal:items>
+        </tal:items>
 
-</html>
+    </html>

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -9,7 +9,7 @@
     </h2>
 
     <tal:items tal:define="items view/block_results;
-        normalizeString nocall:context/@@plone/normalizeString">
+                           normalizeString nocall:context/@@plone/normalizeString">
 
         <p tal:condition="not: items"
            i18n:translate="">No content available</p>
@@ -36,7 +36,7 @@
                                            item_wf_state_class python:'state-' + normalizeString(item_wf_state);
                                            item_creator item/Creator;
                                            item_has_image python:item.getIcon;
-                        ">
+                                           ">
                         <tr metal:define-macro="listitem"
                             tal:define="oddrow repeat/item/odd;"
                             tal:attributes="class python: oddrow and 'even' or 'odd'">
@@ -82,7 +82,7 @@
                                 show_more_link block_info/show_more_link"
                     tal:condition="items">
             <div class="collection-footer"
-                tal:condition="python: more_link_url or rss_url">
+                 tal:condition="python: more_link_url or rss_url">
                 <a class="collection-more"
                    tal:condition="python:more_link_url and show_more_link"
                    title="More"

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -63,7 +63,7 @@
                                 <td tal:condition="python:field == 'Creator'"
                                     i18n:attributes="creator"
                                     tal:define="author python:view.pas_member.info(item_creator);
-                                    name python:author['fullname'] or author['username']">
+                                                name python:author['fullname'] or author['username']">
                                     <a tal:condition="author"
                                        tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
                                        tal:content="name" />
@@ -77,10 +77,10 @@
         </table>
 
         <tal:footer tal:define="more_link_url block_info/more_link_url;
-            more_link_label block_info/more_link_label;
-            rss_url block_info/rss_link_url;
-            show_more_link block_info/show_more_link"
-            tal:condition="items">
+                                more_link_label block_info/more_link_label;
+                                rss_url block_info/rss_link_url;
+                                show_more_link block_info/show_more_link"
+                    tal:condition="items">
             <div class="collection-footer"
                 tal:condition="python: more_link_url or rss_url">
                 <a class="collection-more"

--- a/ftw/collectionblock/browser/templates/listing.pt
+++ b/ftw/collectionblock/browser/templates/listing.pt
@@ -24,15 +24,14 @@
 
       <div metal:use-macro="context/batch_macros/macros/navigation" />
       <div class="has-table">
-        <table class="listing"
+        <table class="listing sortable"
             summary="Content listing"
             i18n:attributes="summary summary_content_listing;">
           <thead>
             <tr>
-              <th class="nosort"
-                  i18n:translate=""
+              <td i18n:translate=""
                   tal:repeat="field view/tabular_fields"
-                  tal:content="field">Field name</th>
+                  tal:content="field">Field name</td>
             </tr>
           </thead>
           <tbody>
@@ -43,6 +42,9 @@
                                      item_type item/PortalType;
                                      item_type_class python:'contenttype-' + view.normalizeString(item_type);
                                      item_wf_state item/review_state;
+                                     item_modified item/ModificationDate;
+                                     item_created item/CreationDate;
+                                     item_icon item/getIcon;
                                      item_wf_state_class python:'state-' + view.normalizeString(item_wf_state);
                                      item_creator item/Creator;
                                      item_link python:item_type in view.use_view_action and item_url+'/view' or item_url">

--- a/ftw/collectionblock/browser/templates/listing.pt
+++ b/ftw/collectionblock/browser/templates/listing.pt
@@ -19,106 +19,86 @@
   </div>
 
   <metal:listingmacro define-macro="listing">
-    <tal:results define="batch view/batch">
-      <tal:listing condition="batch">
-        <div class="entries" metal:define-slot="entries">
-          <tal:repeat repeat="item batch" metal:define-macro="entries">
-            <tal:block tal:define="obj item/getObject;
-                item_url item/getURL;
-                item_id item/getId;
-                item_title item/Title;
-                item_description item/Description;
-                item_type item/PortalType;
-                item_modified item/ModificationDate;
-                item_created item/CreationDate;
-                item_icon item/getIcon;
-                item_type_class python:'contenttype-' + view.normalizeString(item_type);
-                item_wf_state item/review_state;
-                item_wf_state_class python:'state-' + view.normalizeString(item_wf_state);
-                item_creator item/Creator;
-                item_link python:item_type in view.use_view_action and item_url+'/view' or item_url;
-                item_has_image python:view.has_image(obj);
-                item_is_event python:view.is_event(obj)">
-              <metal:block define-slot="entry">
-                <article class="entry">
-                  <header metal:define-macro="listitem" tal:attributes="class python:'vevent' if item_is_event else None">
-                    <span class="summary">
-                      <a tal:attributes="href item_link;
-                                         class string:$item_type_class $item_wf_state_class url;
-                                         title item_type"
+  <tal:results define="batch view/batch">
+    <tal:listing condition="batch">
+
+      <div metal:use-macro="context/batch_macros/macros/navigation" />
+      <div class="has-table">
+        <table class="listing"
+            summary="Content listing"
+            i18n:attributes="summary summary_content_listing;">
+          <thead>
+            <tr>
+              <th class="nosort"
+                  i18n:translate=""
+                  tal:repeat="field view/tabular_fields"
+                  tal:content="field">Field name</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tal:entries tal:repeat="item batch">
+              <tal:block tal:define="item_url item/getURL;
+                                     item_title item/Title;
+                                     item_description item/Description;
+                                     item_type item/PortalType;
+                                     item_type_class python:'contenttype-' + view.normalizeString(item_type);
+                                     item_wf_state item/review_state;
+                                     item_wf_state_class python:'state-' + view.normalizeString(item_wf_state);
+                                     item_creator item/Creator;
+                                     item_link python:item_type in view.use_view_action and item_url+'/view' or item_url">
+                <tr metal:define-macro="listitem"
+                    tal:define="oddrow repeat/item/odd;"
+                    tal:attributes="class python: oddrow and 'even' or 'odd'">
+
+                  <tal:block tal:repeat="field view/tabular_fields">
+                    <td tal:condition="python:field not in ['Title', 'Creator', 'getIcon']"
+                        tal:define="field_data python:view.tabular_fielddata(item, field)">
+                      <tal:block tal:replace="field_data/value" />
+                    </td>
+                    <td tal:condition="python:field == 'Title'">
+                      <img class="image-icon"
+                         tal:define="getIcon python:item.getURL()+'/@@images/image/icon'"
+                         tal:condition="python:  item.getIcon"
+                         tal:attributes="href item/getURL;
+                                         src  string:$getIcon"
+                      />
+                      <a href="#"
+                          tal:attributes="href item_link;
+                          class string:$item_wf_state_class $item_type_class;
+                          title item_description;"
                           tal:content="item_title">
                         Item Title
                       </a>
-                    </span>
+                    </td>
+                    <td tal:condition="python:field == 'Creator'"
+                        tal:define="author python:view.pas_member.info(item_creator);
+                                    name python:author['fullname'] or author['username']">
+                      <a tal:condition="author"
+                          tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
+                          tal:content="name">Jos Henken</a>
+                    </td>
+                  </tal:block>
 
-                    <metal:block metal:define-macro="document_byline">
-                      <span class="documentByLine">
-                        <tal:event condition="item_is_event">
-                          <tal:date tal:replace="structure python:view.formatted_date(obj)"/>
-                          <span tal:condition="item/location" i18n:translate="label_event_byline_location">&mdash;
-                            <span tal:content="string:${item/location}" class="location" i18n:name="location">Oslo</span>,
-                          </span>
-                        </tal:event>
-                        <tal:byline condition="view/show_about">
-                          &mdash;
-                          <tal:name tal:condition="item_creator"
-                              tal:define="author python:view.pas_member.info(item_creator);
-                                          creator_short_form author/username;
-                                          creator_long_form string:?author=${author/username};
-                                          creator_is_openid python:'/' in creator_short_form;
-                                          creator_id python:(creator_short_form, creator_long_form)[creator_is_openid];">
-                          <span i18n:translate="label_by_author">
-                            by
-                            <a tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
-                                tal:content="author/name_or_id"
-                                tal:omit-tag="not:author"
-                                i18n:name="author">
-                              Bob Dobalina
-                            </a>
-                          </span>
-                          </tal:name>
+                </tr>
+              </tal:block>
+            </tal:entries>
+          </tbody>
+        </table>
+      </div>
 
-                          <tal:modified condition="python: item_type != 'Event'">
-                            &mdash;
-                            <tal:mod i18n:translate="box_last_modified">last modified</tal:mod>
-                            <span tal:replace="python:view.toLocalizedTime(item_modified,long_format=1)">
-                              August 16, 2001 at 23:35:59
-                            </span>
-                          </tal:modified>
+      <div metal:use-macro="context/batch_macros/macros/navigation" />
 
-                          <metal:description define-slot="description_slot">
-                            <tal:comment replace="nothing">
-                              Place custom listing info for custom types here
-                            </tal:comment>
-                          </metal:description>
-                        </tal:byline>
-                      </span>
-                    </metal:block>
-                  </header>
-                  <p class="description discreet"
-                      tal:condition="item_description"
-                      tal:content="item_description">
-                    description
-                  </p>
-                </article>
-              </metal:block>
-            </tal:block>
-          </tal:repeat>
-        </div>
+    </tal:listing>
 
-        <div metal:use-macro="context/batch_macros/macros/navigation" />
+    <metal:empty metal:define-slot="no_items_in_listing">
+    <p class="discreet"
+    tal:condition="not: view/batch"
+    tal:content="view/no_items_message">
+    There are currently no items in this folder.
+    </p>
+    </metal:empty>
 
-      </tal:listing>
-
-      <metal:empty metal:define-slot="no_items_in_listing">
-        <p class="discreet"
-            tal:condition="not: view/batch"
-            tal:content="view/no_items_message">
-          There are currently no items in this folder.
-        </p>
-      </metal:empty>
-
-    </tal:results>
+  </tal:results>
   </metal:listingmacro>
 
 </metal:block>

--- a/ftw/collectionblock/browser/templates/listing.pt
+++ b/ftw/collectionblock/browser/templates/listing.pt
@@ -11,10 +11,11 @@
 <metal:block define-macro="content-core">
 
   <div metal:define-macro="text-field-view"
-      id="parent-fieldname-text" class="stx"
-      tal:define="text view/text"
-      tal:condition="text"
-      tal:attributes="class view/text_class">
+       id="parent-fieldname-text"
+       class="stx"
+       tal:define="text view/text"
+       tal:condition="text"
+       tal:attributes="class view/text_class">
     <div metal:define-slot="inside" tal:replace="structure text">The body</div>
   </div>
 
@@ -25,8 +26,8 @@
       <div metal:use-macro="context/batch_macros/macros/navigation" />
       <div class="has-table">
         <table class="listing sortable"
-            summary="Content listing"
-            i18n:attributes="summary summary_content_listing;">
+               summary="Content listing"
+               i18n:attributes="summary summary_content_listing;">
           <thead>
             <tr>
               <td i18n:translate=""
@@ -59,10 +60,10 @@
                     </td>
                     <td tal:condition="python:field == 'Title'">
                       <a href="#"
-                          tal:attributes="href item_link;
-                          class string:$item_wf_state_class $item_type_class;
-                          title item_description;"
-                          tal:content="item_title">
+                         tal:attributes="href item_link;
+                                          class string:$item_wf_state_class $item_type_class;
+                                          title item_description;"
+                         tal:content="item_title">
                         Item Title
                       </a>
                     </td>
@@ -70,8 +71,8 @@
                         tal:define="author python:view.pas_member.info(item_creator);
                                     name python:author['fullname'] or author['username']">
                       <a tal:condition="author"
-                          tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
-                          tal:content="name">Jos Henken</a>
+                         tal:attributes="href string:${view/navigation_root_url}/author/${item_creator}"
+                         tal:content="name">Jos Henken</a>
                     </td>
                   </tal:block>
 
@@ -88,9 +89,9 @@
 
     <metal:empty metal:define-slot="no_items_in_listing">
     <p class="discreet"
-    tal:condition="not: view/batch"
-    tal:content="view/no_items_message">
-    There are currently no items in this folder.
+       tal:condition="not: view/batch"
+       tal:content="view/no_items_message">
+      There are currently no items in this folder.
     </p>
     </metal:empty>
 

--- a/ftw/collectionblock/browser/templates/listing.pt
+++ b/ftw/collectionblock/browser/templates/listing.pt
@@ -1,10 +1,10 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
-    xmlns:tal="http://xml.zope.org/namespaces/tal"
-    xmlns:metal="http://xml.zope.org/namespaces/metal"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    lang="en"
-    metal:use-macro="context/main_template/macros/master"
-    i18n:domain="plone">
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="plone">
 <body>
 
 <metal:content-core fill-slot="content-core">
@@ -61,8 +61,8 @@
                     <td tal:condition="python:field == 'Title'">
                       <a href="#"
                          tal:attributes="href item_link;
-                                          class string:$item_wf_state_class $item_type_class;
-                                          title item_description;"
+                                         class string:$item_wf_state_class $item_type_class;
+                                         title item_description;"
                          tal:content="item_title">
                         Item Title
                       </a>

--- a/ftw/collectionblock/browser/templates/listing.pt
+++ b/ftw/collectionblock/browser/templates/listing.pt
@@ -58,12 +58,6 @@
                       <tal:block tal:replace="field_data/value" />
                     </td>
                     <td tal:condition="python:field == 'Title'">
-                      <img class="image-icon"
-                         tal:define="getIcon python:item.getURL()+'/@@images/image/icon'"
-                         tal:condition="python:  item.getIcon"
-                         tal:attributes="href item/getURL;
-                                         src  string:$getIcon"
-                      />
                       <a href="#"
                           tal:attributes="href item_link;
                           class string:$item_wf_state_class $item_type_class;

--- a/ftw/collectionblock/locales/de/LC_MESSAGES/ftw.collectionblock.po
+++ b/ftw/collectionblock/locales/de/LC_MESSAGES/ftw.collectionblock.po
@@ -27,18 +27,13 @@ msgstr "Kollektions-Block (Add-On für ftw.simplelayout)"
 msgid "Easily build complex queries inside a simplelayout block."
 msgstr "Auf einfache Art komplexe Abfragen in einem Simplelayout Block erstellen."
 
-#: ./ftw/collectionblock/browser/templates/block_view.pt:13
+#: ./ftw/collectionblock/browser/templates/block_view.pt:14
 msgid "No content available"
 msgstr "Kein Inhalt vorhanden"
 
-#: ./ftw/collectionblock/browser/templates/block_view.pt:51
+#: ./ftw/collectionblock/browser/templates/block_view.pt:92
 msgid "Subscribe to the RSS feed"
 msgstr "RSS-Feed abonnieren"
-
-#. Default: "by ${author}"
-#: ./ftw/collectionblock/browser/templates/block_view.pt:25
-msgid "collection_listing_author_label"
-msgstr "von ${author}"
 
 #. Default: "Show title"
 #: ./ftw/collectionblock/contents/collectionblock.py:29
@@ -75,8 +70,8 @@ msgid "label_show_rss_link"
 msgstr "Link zum RSS-Feed"
 
 #. Default: "More"
-#: ./ftw/collectionblock/browser/block_view.py:51
-#: ./ftw/collectionblock/browser/templates/block_view.pt:45
+#: ./ftw/collectionblock/browser/block_view.py:57
+#: ./ftw/collectionblock/browser/templates/block_view.pt:86
 msgid "more_link_label"
 msgstr "Mehr"
 

--- a/ftw/collectionblock/locales/de/LC_MESSAGES/plone.po
+++ b/ftw/collectionblock/locales/de/LC_MESSAGES/plone.po
@@ -1,0 +1,22 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2017-06-27 15:42+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+msgid "Date"
+msgstr "Datum"
+
+msgid "getRemoteUrl"
+msgstr "URL"
+

--- a/ftw/collectionblock/locales/ftw.collectionblock.pot
+++ b/ftw/collectionblock/locales/ftw.collectionblock.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-06-27 15:42+0000\n"
+"POT-Creation-Date: 2018-10-23 08:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,17 +27,12 @@ msgstr ""
 msgid "Easily build complex queries inside a simplelayout block."
 msgstr ""
 
-#: ./ftw/collectionblock/browser/templates/block_view.pt:13
+#: ./ftw/collectionblock/browser/templates/block_view.pt:14
 msgid "No content available"
 msgstr ""
 
-#: ./ftw/collectionblock/browser/templates/block_view.pt:51
+#: ./ftw/collectionblock/browser/templates/block_view.pt:92
 msgid "Subscribe to the RSS feed"
-msgstr ""
-
-#. Default: "by ${author}"
-#: ./ftw/collectionblock/browser/templates/block_view.pt:25
-msgid "collection_listing_author_label"
 msgstr ""
 
 #. Default: "Show title"
@@ -75,8 +70,8 @@ msgid "label_show_rss_link"
 msgstr ""
 
 #. Default: "More"
-#: ./ftw/collectionblock/browser/block_view.py:51
-#: ./ftw/collectionblock/browser/templates/block_view.pt:45
+#: ./ftw/collectionblock/browser/block_view.py:57
+#: ./ftw/collectionblock/browser/templates/block_view.pt:86
 msgid "more_link_label"
 msgstr ""
 

--- a/ftw/collectionblock/locales/plone.pot
+++ b/ftw/collectionblock/locales/plone.pot
@@ -1,0 +1,21 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2017-06-27 15:42+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+msgid "getRemoteUrl"
+msgstr ""
+
+msgid "Date"
+msgstr ""

--- a/ftw/collectionblock/tests/test_add_collecionblock.py
+++ b/ftw/collectionblock/tests/test_add_collecionblock.py
@@ -78,7 +78,13 @@ class TestAddCollectionBlock(FunctionalTestCase):
         self.assertEquals(
             '{0}/listing_view'.format(collectionblock.absolute_url()),
             browser.url)
-        self.assertEquals(1, len(browser.css('.entries article')))
+            
+        self.assertEquals(
+            [{'Title': 'Test Page',
+              'Creator': 'test-user',
+              'Type': 'ContentPage',
+              'ModificationDate': browser.css('tbody tr td')[3].text}],
+            browser.css('table.sortable').first.dicts())
 
     @browsing
     def test_custom_more_label(self, browser):

--- a/ftw/collectionblock/tests/test_add_collecionblock.py
+++ b/ftw/collectionblock/tests/test_add_collecionblock.py
@@ -1,10 +1,10 @@
+from Products.CMFPlone.interfaces.syndication import ISiteSyndicationSettings
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.collectionblock.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from plone.registry.interfaces import IRegistry
-from Products.CMFPlone.interfaces.syndication import ISiteSyndicationSettings
 from zope.component import getUtility
 import transaction
 
@@ -15,13 +15,12 @@ class TestAddCollectionBlock(FunctionalTestCase):
         super(TestAddCollectionBlock, self).setUp()
         self.grant('Manager')
 
-        self.page = create(Builder('sl content page').titled(u'A page'))
+        self.page = create(Builder('sl content page').titled(u'Test Page'))
 
     @browsing
     def test_add_collection_block(self, browser):
         browser.login().visit(self.page)
         factoriesmenu.add('Collection block')
-
         title = u'A collection block'
         browser.fill({'Title': title, 'Show title': True})
         browser.find_button_by_label('Save').click()
@@ -60,15 +59,13 @@ class TestAddCollectionBlock(FunctionalTestCase):
                .with_default_query())
 
         # The default query shows all Simplelayout Contentpages
-
         browser.login().visit(self.page)
         self.assertEquals(
             1,
-            len(browser.css('.ftw-collectionblock-collectionblock h3')))
-
+            len(browser.css('.odd')))
         self.assertEquals(
             self.page.Title(),
-            browser.css('.ftw-collectionblock-collectionblock h3').first.text)
+            browser.css('.documentFirstHeading').first.text)
 
     @browsing
     def test_detail_view_on_collectionblock(self, browser):
@@ -78,7 +75,6 @@ class TestAddCollectionBlock(FunctionalTestCase):
                                  .with_default_query())
         browser.login().visit(self.page)
         browser.css('.collection-more').first.click()
-
         self.assertEquals(
             '{0}/listing_view'.format(collectionblock.absolute_url()),
             browser.url)
@@ -153,6 +149,30 @@ class TestAddCollectionBlock(FunctionalTestCase):
 
         browser.login().visit(self.page)
         self.assertEquals(
-            2,
-            len(browser.css('.ftw-collectionblock-collectionblock h3'))
+            1,
+            len(browser.css('.even'))
         )
+
+    @browsing
+    def test_is_table(self, browser):
+        create(Builder('sl content page').titled(u'Page 2'))
+        create(Builder('sl content page').titled(u'Page 3'))
+
+        create(Builder('sl collectionblock')
+               .titled(u'A collectionblock')
+               .within(self.page)
+               .having(block_amount=2)
+               .with_default_query())
+
+        browser.login().visit(self.page)
+
+        self.assertEquals(
+            [{'Title': 'Test Page',
+              'Creator': 'test-user',
+              'Type': 'ContentPage',
+              'ModificationDate': browser.css('tbody tr td')[3].text},
+             {'Title': 'Page 2',
+              'Creator': 'test-user',
+              'Type': 'ContentPage',
+              'ModificationDate': browser.css('tbody tr td')[3].text}],
+            browser.css('table.sortable').first.dicts())


### PR DESCRIPTION
To make the collectionblock more usable I changed the it to a table layout. The earlier block with its list view used to have very little attraction to add to a page.

This is a shot of an example of the new layout.

![image](https://user-images.githubusercontent.com/29920936/46852061-eb1e9180-cdf9-11e8-9978-e6a94aa9648d.png)

Also the table layout is sortable by clicking its header attributes (asc and desc).

The detailed view also comes in a table layout now like:

![image](https://user-images.githubusercontent.com/29920936/46862423-119df600-ce15-11e8-9671-c0034408abf7.png)

