### PR TITLE
Customization support for link target.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Customization support for link target. [jone]
 
 
 1.0.7 (2018-11-05)

--- a/ftw/collectionblock/browser/block_view.py
+++ b/ftw/collectionblock/browser/block_view.py
@@ -34,6 +34,13 @@ class CollectionBlockView(BaseBlock):
             return self.context.results(b_size=self.context.block_amount)
         return self.context.results()
 
+    def get_title_link_target(self, item):
+        """This method may return a target attribute value (e.g. "_blank").
+        It can be customized by subclasses.
+        The "item" is a content listing object wrapper item.
+        """
+        return None
+
     def get_author(self, item):
         author = ''
         if utils.can_view_about():

--- a/ftw/collectionblock/browser/templates/block_view.pt
+++ b/ftw/collectionblock/browser/templates/block_view.pt
@@ -57,7 +57,8 @@
                                     </a>
                                     <a tal:attributes="href item_url;
                                                        class string:$item_type_class $item_wf_state_class;
-                                                       title item_type"
+                                                       title item_type;
+                                                       target python:view.get_title_link_target(item)"
                                        tal:content="item_title" />
                                 </td>
                                 <td tal:condition="python:field == 'Creator'"


### PR DESCRIPTION
Provide a new method "get_title_link_target", which may provide a string to be used as target attribute for the title link rendered in the content listing table.